### PR TITLE
fix: newAPIError function panic

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -487,7 +487,14 @@ func newAPIError(resp *http.Response) error {
 			// Handle plain text error message. File upload backend doesn't return json error message.
 			return APIError{Code: resp.StatusCode, Status: resp.Status, Message: string(body)}
 		}
-		return *respWithError.ErrorInfo
+
+		// Check if we successfully parsed an error response
+		if respWithError.ErrorInfo != nil {
+			return *respWithError.ErrorInfo
+		}
+
+		// Valid JSON but no error field - treat as generic error with body content
+		return APIError{Code: resp.StatusCode, Status: resp.Status, Message: string(body)}
 	}
 	return APIError{Code: resp.StatusCode, Status: resp.Status}
 }


### PR DESCRIPTION
## Problem

The `newAPIError` function in `api_client.go` has improper error handling that can cause nil pointer dereference panics.

When the API returns valid JSON that doesn't match the expected `responseWithError` format (e.g., missing error field or `error: null`), the JSON unmarshaling still succeeds but leaves `ErrorInfo` as `nil`. The code then dereferences this nil pointer with `*respWithError.ErrorInfo`, causing a "invalid memory address or nil pointer dereference" panic.

## Failure Cases

1) API returns `{"some_field": "value"}` (valid JSON, no error field). JSON unmarshaling succeeds → ErrorInfo is nil. Code executes `return *respWithError.ErrorInfo` → nil pointer dereference panic
2) API returns `{"error": null, "other": "data"}` (valid JSON, explicit null error). JSON unmarshaling succeeds → ErrorInfo is nil. Code executes `return *respWithError.ErrorInfo` → nil pointer dereference panic

## Fix
Add explicit nil check before dereferencing `ErrorInfo`