### PR TITLE
fix(vertex): fix authorization header missing for vertex backend

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -262,8 +262,20 @@ func buildRequest(ctx context.Context, ac *apiClient, path string, body map[stri
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	if ac.clientConfig.APIKey != "" {
-		req.Header.Set("x-goog-api-key", ac.clientConfig.APIKey)
+
+	switch ac.clientConfig.Backend {
+	case BackendVertexAI:
+		if ac.clientConfig.Credentials != nil {
+			token, err := ac.clientConfig.Credentials.Token(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get token: %w", err)
+			}
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Value))
+		}
+	case BackendGeminiAPI:
+		if ac.clientConfig.APIKey != "" {
+			req.Header.Set("x-goog-api-key", ac.clientConfig.APIKey)
+		}
 	}
 
 	return req, patchedHTTPOptions, nil

--- a/api_client_test.go
+++ b/api_client_test.go
@@ -777,7 +777,7 @@ func TestBuildRequest(t *testing.T) {
 				Location:    "test-location",
 				Backend:     BackendVertexAI,
 				HTTPClient:  &http.Client{},
-				Credentials: &auth.Credentials{},
+				Credentials: &auth.Credentials{TokenProvider: vertexTokenProvider{}},
 			},
 			path:   "models/test-model:generateContent",
 			body:   map[string]any{"key": "value"},
@@ -797,6 +797,7 @@ func TestBuildRequest(t *testing.T) {
 					Path:   "/v1beta1/projects/test-project/locations/test-location/models/test-model:generateContent",
 				},
 				Header: http.Header{
+					"Authorization":     []string{"Bearer vertex-token"},
 					"Content-Type":      []string{"application/json"},
 					"X-Test-Header":     []string{"test-value"},
 					"User-Agent":        []string{fmt.Sprintf("google-genai-sdk/%s gl-go/%s", version, runtime.Version())},
@@ -813,7 +814,7 @@ func TestBuildRequest(t *testing.T) {
 				Location:    "test-location",
 				Backend:     BackendVertexAI,
 				HTTPClient:  &http.Client{},
-				Credentials: &auth.Credentials{},
+				Credentials: &auth.Credentials{TokenProvider: vertexTokenProvider{}},
 			},
 			path:   "projects/test-project/locations/test-location/models/test-model:generateContent",
 			body:   map[string]any{"key": "value"},
@@ -833,6 +834,7 @@ func TestBuildRequest(t *testing.T) {
 					Path:   "/v1beta1/projects/test-project/locations/test-location/models/test-model:generateContent",
 				},
 				Header: http.Header{
+					"Authorization":     []string{"Bearer vertex-token"},
 					"Content-Type":      []string{"application/json"},
 					"X-Test-Header":     []string{"test-value"},
 					"User-Agent":        []string{fmt.Sprintf("google-genai-sdk/%s gl-go/%s", version, runtime.Version())},
@@ -849,7 +851,7 @@ func TestBuildRequest(t *testing.T) {
 				Location:    "test-location",
 				Backend:     BackendVertexAI,
 				HTTPClient:  &http.Client{},
-				Credentials: &auth.Credentials{},
+				Credentials: &auth.Credentials{TokenProvider: vertexTokenProvider{}},
 			},
 			path:   "publishers/google/models/model-name",
 			body:   map[string]any{},
@@ -866,6 +868,7 @@ func TestBuildRequest(t *testing.T) {
 					Path:   "/v1beta1/publishers/google/models/model-name",
 				},
 				Header: http.Header{
+					"Authorization":     []string{"Bearer vertex-token"},
 					"Content-Type":      []string{"application/json"},
 					"User-Agent":        []string{fmt.Sprintf("google-genai-sdk/%s gl-go/%s", version, runtime.Version())},
 					"X-Goog-Api-Client": []string{fmt.Sprintf("google-genai-sdk/%s gl-go/%s", version, runtime.Version())},
@@ -912,7 +915,7 @@ func TestBuildRequest(t *testing.T) {
 				Location:    "test-location",
 				Backend:     BackendVertexAI,
 				HTTPClient:  &http.Client{},
-				Credentials: &auth.Credentials{},
+				Credentials: &auth.Credentials{TokenProvider: vertexTokenProvider{}},
 			},
 			path:   "models/test-model:generateContent",
 			body:   map[string]any{},
@@ -929,6 +932,7 @@ func TestBuildRequest(t *testing.T) {
 					Path:   "/v1beta1/projects/test-project/locations/test-location/models/test-model:generateContent",
 				},
 				Header: http.Header{
+					"Authorization":     []string{"Bearer vertex-token"},
 					"Content-Type":      []string{"application/json"},
 					"User-Agent":        []string{fmt.Sprintf("google-genai-sdk/%s gl-go/%s", version, runtime.Version())},
 					"X-Goog-Api-Client": []string{fmt.Sprintf("google-genai-sdk/%s gl-go/%s", version, runtime.Version())},
@@ -1747,4 +1751,10 @@ func TestRecursiveMapMerge(t *testing.T) {
 			}
 		})
 	}
+}
+
+type vertexTokenProvider struct{}
+
+func (vertexTokenProvider) Token(ctx context.Context) (*auth.Token, error) {
+	return &auth.Token{Value: "vertex-token"}, nil
 }

--- a/client.go
+++ b/client.go
@@ -266,7 +266,7 @@ func NewClient(ctx context.Context, cc *ClientConfig) (*Client, error) {
 		}
 	}
 
-	if cc.Backend == BackendVertexAI && cc.Credentials == nil && cc.APIKey == "" && cc.HTTPClient == nil {
+	if cc.Backend == BackendVertexAI && cc.Credentials == nil && cc.APIKey == "" {
 		cred, err := credentials.DetectDefault(&credentials.DetectOptions{
 			Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
 		})

--- a/live.go
+++ b/live.go
@@ -70,7 +70,9 @@ func (r *Live) Connect(context context.Context, model string, config *LiveConnec
 
 	var u url.URL
 	var header http.Header = mergeHeaders(&httpOptions, nil)
-	if r.apiClient.clientConfig.Backend == BackendVertexAI {
+
+	switch r.apiClient.clientConfig.Backend {
+	case BackendVertexAI:
 		token, err := r.apiClient.clientConfig.Credentials.Token(context)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get token: %w", err)
@@ -81,7 +83,7 @@ func (r *Live) Connect(context context.Context, model string, config *LiveConnec
 			Host:   baseURL.Host,
 			Path:   path.Join(baseURL.Path, fmt.Sprintf("ws/google.cloud.aiplatform.%s.LlmBidiService/BidiGenerateContent", httpOptions.APIVersion)),
 		}
-	} else {
+	case BackendGeminiAPI:
 		apiKey := r.apiClient.clientConfig.APIKey
 		if apiKey != "" {
 			header.Set("x-goog-api-key", apiKey)


### PR DESCRIPTION
I was working with the SDK, and noticed that it wasn't working properly for Vertex, despite working fine for Gemini. It required me quite some debugging to understand what was happening.

The issue was basically that I was always receiving a 401 when using Vertex. After some digging, I noticed that the `Authorization` header was simply always missing. I had to look for the code to see what was happening, and was able to found and fix a couple of bugs.