### PR TITLE
fix(docs): correct example for GenerateContent using an HTTP URL

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -508,7 +508,7 @@ func ExampleModels_GenerateContent_httpURL_vertexai() {
 	}
 	contents := []*genai.Content{{Parts: parts}}
 
-	result, err := client.Models.GenerateContent(ctx, "gemini-2.5-flash", contents, nil)
+	result, err := client.Models.GenerateContent(ctx, "gemini-flash-latest", contents, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The current example does not work. It suggests one can directly create a `genai.Part` from an image URL such as `https://storage.googleapis.com/cloud-samples-data/generative-ai/image/scones.jpg`, but it is not possible.

One workaround is to download the file and store it in-memory, so we can create a `genai.Part` from the bytes of a file. This is done in the example for document processing using the same Go SDK: https://ai.google.dev/gemini-api/docs/document-processing#inline_data

I created a repo to show that the current example does not work, and the new example provided by this PR works. See https://github.com/Daquisu/go-genai-example