### PR TITLE
Change Role type from string to Role

### DIFF
--- a/jayashreen1995@gmail.com
+++ b/jayashreen1995@gmail.com
@@ -1141,7 +1141,7 @@ type Content struct {
 	Parts []*Part `json:"parts,omitempty"`
 	// Optional. The producer of the content. Must be either 'user' or 'model'. Useful to
 	// set for multi-turn conversations, otherwise can be left blank or unset.
-	Role string `json:"role,omitempty"`
+	Role Role `json:"role,omitempty"`
 }
 
 type Role string


### PR DESCRIPTION
The `Role` type has been created but never used; `string` type has been used instead. I changed the `Role` type to be of `Role` instead of `string` in the `Content` struct.