### PR TITLE
fix: Change Role field type from string to Role

### DIFF
--- a/types.go
+++ b/types.go
@@ -1207,7 +1207,7 @@ type Content struct {
 	Parts []*Part `json:"parts,omitempty"`
 	// Optional. The producer of the content. Must be either 'user' or 'model'. Useful to
 	// set for multi-turn conversations, otherwise can be left blank or unset.
-	Role string `json:"role,omitempty"`
+	Role Role `json:"role,omitempty"`
 }
 
 type Role string


### PR DESCRIPTION
The `Role` type has been created but never used where it is supposed to be used. `string` type has been used instead in the `Content` struct. I changed the `Role` fields type to be of `Role` instead of `string` in the `Content` struct.