### PR TITLE
feat: add Parallel AI Search tool support

### DIFF
--- a/examples/models/generate_content/parallel_ai_search.go
+++ b/examples/models/generate_content/parallel_ai_search.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build ignore_vet
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+
+	"google.golang.org/genai"
+)
+
+var model = flag.String("model", "gemini-2.5-flash", "the model name, e.g. gemini-2.5-flash")
+var parallelAPIKey = flag.String("parallel-api-key", "", "Parallel AI Search API key (required)")
+
+func run(ctx context.Context) {
+	client, err := genai.NewClient(ctx, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if client.ClientConfig().Backend != genai.BackendVertexAI {
+		log.Fatal("Parallel AI Search is only supported with Vertex AI backend")
+	}
+	fmt.Println("Calling VertexAI Backend...")
+
+	config := &genai.GenerateContentConfig{
+		Tools: []*genai.Tool{{
+			ParallelAiSearch: &genai.ParallelAiSearch{
+				APIKey: *parallelAPIKey,
+				CustomConfigs: &genai.ParallelAiSearchCustomConfigs{
+					MaxResults: genai.Ptr[int32](5),
+				},
+			},
+		}},
+	}
+
+	result, err := client.Models.GenerateContent(ctx, *model, genai.Text("What are the latest developments in AI?"), config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Response:", result.Text())
+	if len(result.Candidates) > 0 && result.Candidates[0].GroundingMetadata != nil {
+		jsonData, _ := json.MarshalIndent(result.Candidates[0].GroundingMetadata, "", "  ")
+		fmt.Println("Grounding metadata:", string(jsonData))
+	}
+}
+
+func main() {
+	ctx := context.Background()
+	flag.Parse()
+	if *parallelAPIKey == "" {
+		log.Fatal("--parallel-api-key is required")
+	}
+	run(ctx)
+}

--- a/models.go
+++ b/models.go
@@ -3570,6 +3570,10 @@ func toolToMldev(fromObject map[string]any, parentObject map[string]any, rootObj
 		setValueByPath(toObject, []string{"googleSearchRetrieval"}, fromGoogleSearchRetrieval)
 	}
 
+	if getValueByPath(fromObject, []string{"parallelAiSearch"}) != nil {
+		return nil, fmt.Errorf("parallelAiSearch parameter is not supported in Gemini API")
+	}
+
 	fromUrlContext := getValueByPath(fromObject, []string{"urlContext"})
 	if fromUrlContext != nil {
 		setValueByPath(toObject, []string{"urlContext"}, fromUrlContext)
@@ -3628,6 +3632,11 @@ func toolToVertex(fromObject map[string]any, parentObject map[string]any, rootOb
 	fromGoogleSearchRetrieval := getValueByPath(fromObject, []string{"googleSearchRetrieval"})
 	if fromGoogleSearchRetrieval != nil {
 		setValueByPath(toObject, []string{"googleSearchRetrieval"}, fromGoogleSearchRetrieval)
+	}
+
+	fromParallelAiSearch := getValueByPath(fromObject, []string{"parallelAiSearch"})
+	if fromParallelAiSearch != nil {
+		setValueByPath(toObject, []string{"parallelAiSearch"}, fromParallelAiSearch)
 	}
 
 	fromUrlContext := getValueByPath(fromObject, []string{"urlContext"})

--- a/types.go
+++ b/types.go
@@ -17,7 +17,6 @@
 package genai
 
 import (
-	"cloud.google.com/go/civil"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,6 +24,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"cloud.google.com/go/civil"
 )
 
 // Outcome of the code execution.
@@ -1884,6 +1885,41 @@ type GoogleSearchRetrieval struct {
 	DynamicRetrievalConfig *DynamicRetrievalConfig `json:"dynamicRetrievalConfig,omitempty"`
 }
 
+// ParallelAiSearchSourcePolicy configures domain inclusion/exclusion for Parallel AI Search.
+type ParallelAiSearchSourcePolicy struct {
+	// Domains to exclude from search results. Up to 10 items.
+	ExcludeDomains []string `json:"exclude_domains,omitempty"`
+	// Domains to include in search results. Up to 10 items.
+	IncludeDomains []string `json:"include_domains,omitempty"`
+}
+
+// ParallelAiSearchExcerpts configures excerpt length limits for Parallel AI Search.
+type ParallelAiSearchExcerpts struct {
+	// Maximum characters per individual search result. Default 30000, range [1000, 100000].
+	MaxCharsPerResult *int32 `json:"max_chars_per_result,omitempty"`
+	// Maximum total characters across all results. Default 100000, range [1000, 1000000].
+	MaxCharsTotal *int32 `json:"max_chars_total,omitempty"`
+}
+
+// ParallelAiSearchCustomConfigs contains optional configuration for Parallel AI Search.
+type ParallelAiSearchCustomConfigs struct {
+	// Domain inclusion/exclusion policy.
+	SourcePolicy *ParallelAiSearchSourcePolicy `json:"source_policy,omitempty"`
+	// Excerpt length configuration.
+	Excerpts *ParallelAiSearchExcerpts `json:"excerpts,omitempty"`
+	// Maximum number of search results. Default 10, range [1, 20].
+	MaxResults *int32 `json:"max_results,omitempty"`
+}
+
+// ParallelAiSearch configures grounding with Parallel Web Systems' search API.
+// This field is not supported in Gemini API.
+type ParallelAiSearch struct {
+	// Required. API key for Parallel AI Search.
+	APIKey string `json:"api_key,omitempty"`
+	// Optional configuration for search behavior.
+	CustomConfigs *ParallelAiSearchCustomConfigs `json:"customConfigs,omitempty"`
+}
+
 // Tool to support URL context.
 type URLContext struct {
 }
@@ -1919,6 +1955,9 @@ type Tool struct {
 	GoogleSearch *GoogleSearch `json:"googleSearch,omitempty"`
 	// Optional. Specialized retrieval tool that is powered by Google Search.
 	GoogleSearchRetrieval *GoogleSearchRetrieval `json:"googleSearchRetrieval,omitempty"`
+	// Optional. Parallel AI Search tool type. Tool to support grounding with Parallel
+	// Web Systems' search API. This field is not supported in Gemini API.
+	ParallelAiSearch *ParallelAiSearch `json:"parallelAiSearch,omitempty"`
 	// Optional. Tool to support URL context retrieval.
 	URLContext *URLContext `json:"urlContext,omitempty"`
 }


### PR DESCRIPTION
#### Summary
Add `ParallelAiSearch` as a new `Tool` type for grounding with [Parallel Web Systems' search API](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-parallel) (Vertex AI only)

Transformer passthrough for Vertex AI, rejection for Gemini API
E2E example binary at `examples/models/generate_content/parallel_ai_search.go`

#### Test plan
- [x] E2E tested with valid Parallel API key — returns grounded response with `groundingMetadata`
- [x] E2E tested with invalid API key — returns `PERMISSION_DENIED: Parallel AI API returned authentication error`