### PR TITLE
fix: correct exponential backoff by replacing XOR with bit shift

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -38,7 +38,6 @@ import (
 const maxChunkSize = 8 * 1024 * 1024 // 8 MB chunk size
 const maxRetryCount = 3
 const initialRetryDelay = time.Second
-const delayMultiplier = 2
 
 type apiClient struct {
 	clientConfig *ClientConfig
@@ -650,7 +649,7 @@ func (ac *apiClient) upload(ctx context.Context, r io.Reader, uploadURL string, 
 			select {
 			case <-ctx.Done():
 				return nil, fmt.Errorf("upload aborted while waiting to retry (attempt %d, offset %d): %w", attempt+1, offset, ctx.Err())
-			case <-time.After(initialRetryDelay * time.Duration(delayMultiplier^attempt)):
+			case <-time.After(initialRetryDelay * time.Duration(1<<attempt)):
 				// Sleep completed, continue to the next attempt.
 			}
 		}


### PR DESCRIPTION
## Description

- Fixes a logical error in the exponential backoff calculation for file uploads by replacing the bitwise XOR operator with a bit shift.

## Problem:

- The retry logic currently uses the bitwise XOR operator (`^`), which is a logical error for exponential backoff in Go. This causes the retry delay to drop to 0 seconds on the third attempt.

```
With delayMultiplier = 2:

Attempt 0: 2 ^ 0 = 2
Attempt 1: 2 ^ 1 = 3
Attempt 2: 2 ^ 2 = 0
```

## Solution

Replaced `delayMultiplier^attempt` with `1 << attempt` to ensure proper exponential backoff (1s, 2s, 4s...).