### PR TITLE
fix: use pointer type for AddWatermark to allow disabling watermarks

### DIFF
--- a/types.go
+++ b/types.go
@@ -3616,7 +3616,7 @@ type GenerateImagesConfig struct {
 	// only).
 	OutputCompressionQuality *int32 `json:"outputCompressionQuality,omitempty"`
 	// Optional. Whether to add a watermark to the generated images.
-	AddWatermark bool `json:"addWatermark,omitempty"`
+	AddWatermark *bool `json:"addWatermark,omitempty"`
 	// Optional. User specified labels to track billing usage.
 	Labels map[string]string `json:"labels,omitempty"`
 	// Optional. The size of the largest dimension of the generated image.


### PR DESCRIPTION
## Summary
- Change `AddWatermark` from `bool` to `*bool` in `GenerateImagesConfig` struct
- This ensures explicit `false` values are serialized in JSON instead of being dropped by `omitempty`
- Aligns with the other two `AddWatermark` fields in the codebase which already use `*bool`

Fixes #714

## Test plan
- [x] `go build ./...` passes
- [x] All image-related tests pass
- [ ] Verify API call includes `"addWatermark": false` when set